### PR TITLE
Fix dev image workflow bug

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -66,7 +66,7 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${{ matrix.arch }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-$SHORT_SHA-${{ matrix.arch }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${{ env.SHORT_SHA }}-${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.arch }}-dev
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}-dev
@@ -110,12 +110,12 @@ jobs:
       - name: Create multi-platform dev-shortsha manifest
         run: |
           docker buildx imagetools create \
-            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${SHORT_SHA}" \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${SHORT_SHA}-amd64" \
-            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${SHORT_SHA}-arm64"
+            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${{ env.SHORT_SHA }}" \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${{ env.SHORT_SHA }}-amd64" \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${{ env.SHORT_SHA }}-arm64"
 
       - name: Inspect manifest (dev)
         run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
 
       - name: Inspect manifest (dev-shortsha)
-        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${SHORT_SHA}
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${{ env.SHORT_SHA }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/dev-image.yml` workflow to consistently use the `${{ env.SHORT_SHA }}` environment variable syntax instead of the previously used `$SHORT_SHA` shell variable syntax. This change ensures that the workflow references the correct environment variable format for GitHub Actions.

Workflow variable usage improvements:

* Updated all references to the short SHA in Docker image tags and manifest creation steps to use `${{ env.SHORT_SHA }}` instead of `$SHORT_SHA`, ensuring proper environment variable resolution in GitHub Actions workflows. [[1]](diffhunk://#diff-c646237bfc84e5648a612a01c463878ef7f788c5fc3ffc00ee960b136bac0934L69-R69) [[2]](diffhunk://#diff-c646237bfc84e5648a612a01c463878ef7f788c5fc3ffc00ee960b136bac0934L113-R121)